### PR TITLE
Fix problem with pantheon terminus auth

### DIFF
--- a/commands/host/pantheon-terminus
+++ b/commands/host/pantheon-terminus
@@ -18,14 +18,14 @@ ddev exec "command -v terminus >/dev/null 2>&1 || {
 
 # Authenticate with Pantheon using global token (if available and not already authenticated)
 # The TERMINUS_MACHINE_TOKEN is automatically available from the web container environment
-ddev exec "terminus auth:whoami >/dev/null 2>&1 || {
+ddev exec "if terminus auth:whoami 2>&1 | grep -q 'You are not logged in'; then
     if [ -n \"\${TERMINUS_MACHINE_TOKEN:-}\" ]; then
         terminus auth:login --machine-token=\"\${TERMINUS_MACHINE_TOKEN}\"
     else
         echo 'TERMINUS_MACHINE_TOKEN not set globally. Please run:'
         echo 'ddev config global --web-environment-add=TERMINUS_MACHINE_TOKEN=your_token'
     fi
-}"
+fi"
 
 # Run terminus command
 ddev exec "terminus $*"


### PR DESCRIPTION
## Description
- [x] Was AI used in this pull request?

Currently the `pantheon-terminus` command attempts to see if the user is authenticated before running the actual command, but this check returns a false positive. If the host is not authenticated, the message "[notice] You are not logged in." appears, but still has an exit code of zero, thereby still passing the test. This pull request checks for the message rather than relying on the exit code.
