### PR TITLE
Upsun Configuration

### DIFF
--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -144,6 +144,7 @@ case "$HOST_PROVIDER" in
         echo "--------------------------"
         prompt_input "Site machine name (e.g., my-site)" "${CURRENT_SITE}" HOSTING_SITE
         prompt_input "Default environment (dev/test/live)" "${CURRENT_ENV:-dev}" HOSTING_ENV
+	NGINX_FILE_PROXY="https://${CURRENT_ENV}-${CURRENT_SITE}.pantheonsite.io"
         ;;
     "acquia")
         echo "🔷 Acquia Configuration:"
@@ -257,6 +258,7 @@ case "$HOST_PROVIDER" in
             write_config_var "APACHE_FILE_PROXY" "$APACHE_FILE_PROXY"
         fi
         ;;
+    "pantheon")
     "upsun")
         if [ -n "$NGINX_FILE_PROXY" ]; then
             write_config_var "NGINX_FILE_PROXY" "$NGINX_FILE_PROXY"

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -258,8 +258,7 @@ case "$HOST_PROVIDER" in
             write_config_var "APACHE_FILE_PROXY" "$APACHE_FILE_PROXY"
         fi
         ;;
-    "pantheon")
-    "upsun")
+    "pantheon"|"upsun")
         if [ -n "$NGINX_FILE_PROXY" ]; then
             write_config_var "NGINX_FILE_PROXY" "$NGINX_FILE_PROXY"
         fi

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -295,7 +295,7 @@ case "$HOST_PROVIDER" in
         ;;
     "upsun")
         ddev config --web-environment-add="PLATFORM_APPLICATION_NAME=drupal"
-        ddev config --web-environment-add="PLATFORM_PROJECT=${HOSITNG_SITE}"
+        ddev config --web-environment-add="PLATFORM_PROJECT=${HOSTING_SITE}"
         ddev config --web-environment-add="PLATFORM_ENVIRONMENT=${HOSTING_ENV}"
         if ! ddev add-on list | grep -q "ddev-platformsh"; then
             echo "Installing Platformsh add-on Upsun..."

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -158,12 +158,14 @@ case "$HOST_PROVIDER" in
     "upsun")
         echo "🔷 Upsun Configuration:"
         echo "-----------------------"
-        prompt_input "Application name (e.g., my-app)" "${CURRENT_SITE}" HOSTING_SITE
-        prompt_input "Default environment" "${CURRENT_ENV}" HOSTING_ENV
+        prompt_input "Project ID (e.g., Abc1234D)" "${CURRENT_SITE}" HOSTING_SITE
+        prompt_input "Default environment (Branch hosting production) (e.g., main)" "${CURRENT_ENV}" HOSTING_ENV
         echo ""
         echo "🔗 File Proxy Configuration:"
         prompt_input "Proxy URL for missing files (e.g., https://your-site.com)" "${CURRENT_NGINX_FILE_PROXY}" NGINX_FILE_PROXY
         ;;
+
+
 esac
 
 # Get theme configuration
@@ -294,7 +296,8 @@ case "$HOST_PROVIDER" in
         echo "✅ Memcached configured for Acquia"
         ;;
     "upsun")
-        ddev config --web-environment-add="PLATFORM_APPLICATION_NAME=drupal"
+        APPLICATION_NAME=$(cat ${DDEV_APPROOT}/.platform.app.yaml | docker run -i --rm ddev/ddev-utilities yq '.name')
+        ddev config --web-environment-add="PLATFORM_APPLICATION_NAME=${APPLICATION_NAME}"
         ddev config --web-environment-add="PLATFORM_PROJECT=${HOSTING_SITE}"
         ddev config --web-environment-add="PLATFORM_ENVIRONMENT=${HOSTING_ENV}"
         if ! ddev add-on list --installed | grep -q "ddev-platformsh"; then

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -96,6 +96,7 @@ CURRENT_THEMENAME=$(ddev exec printenv THEMENAME 2>/dev/null || echo "")
 CURRENT_MIGRATE_SOURCE=$(ddev exec printenv MIGRATE_DB_SOURCE 2>/dev/null || echo "")
 CURRENT_MIGRATE_ENV=$(ddev exec printenv MIGRATE_DB_ENV 2>/dev/null || echo "")
 CURRENT_APACHE_FILE_PROXY=$(ddev exec printenv APACHE_FILE_PROXY 2>/dev/null || echo "")
+CURRENT_NGINX_FILE_PROXY=$(ddev exec printenv NGINX_FILE_PROXY 2>/dev/null || echo "")
 
 # Show current configuration
 echo "📋 Current Configuration:"
@@ -115,6 +116,11 @@ case "${CURRENT_PROVIDER:-not set}" in
         echo "Acquia Environment: ${CURRENT_ENV:-not set}"
         echo "Apache File Proxy: ${CURRENT_APACHE_FILE_PROXY:-not set}"
         ;;
+    "upsun")
+        echo "Upsun Application: ${CURRENT_SITE:-not set}"
+        echo "Upsun Environment: ${CURRENT_ENV:-not set}"
+        echo "Nginx File Proxy: ${CURRENT_NGINX_FILE_PROXY:-not set}"
+        ;;
     *)
         echo "(Provider-specific settings will appear after selecting a provider)"
         ;;
@@ -127,7 +133,7 @@ echo ""
 # Get hosting provider
 echo "🏛️ Hosting Provider Configuration:"
 echo "----------------------------------"
-HOST_PROVIDER=$(select_option "Select your hosting provider:" "pantheon" "acquia")
+HOST_PROVIDER=$(select_option "Select your hosting provider:" "pantheon" "acquia", "upsun")
 echo "✓ Selected: $HOST_PROVIDER"
 
 # Get hosting-specific configuration
@@ -147,6 +153,15 @@ case "$HOST_PROVIDER" in
         echo ""
         echo "🔗 File Proxy Configuration:"
         prompt_input "Proxy URL for missing files (e.g., https://your-site.com)" "${CURRENT_APACHE_FILE_PROXY}" APACHE_FILE_PROXY
+        ;;
+    "upsun")
+        echo "🔷 Upsun Configuration:"
+        echo "-----------------------"
+        prompt_input "Application name (e.g., my-app)" "${CURRENT_SITE}" HOSTING_SITE
+        prompt_input "Default environment" "${CURRENT_ENV}" HOSTING_ENV
+        echo ""
+        echo "🔗 File Proxy Configuration:"
+        prompt_input "Proxy URL for missing files (e.g., https://your-site.com)" "${CURRENT_NGINX_FILE_PROXY}" NGINX_FILE_PROXY
         ;;
 esac
 
@@ -242,6 +257,11 @@ case "$HOST_PROVIDER" in
             write_config_var "APACHE_FILE_PROXY" "$APACHE_FILE_PROXY"
         fi
         ;;
+    "upsun")
+        if [ -n "$NGINX_FILE_PROXY" ]; then
+            write_config_var "NGINX_FILE_PROXY" "$NGINX_FILE_PROXY"
+        fi
+        ;;
 esac
 
 # Install provider-specific caching add-on
@@ -271,6 +291,16 @@ case "$HOST_PROVIDER" in
             echo "settings.ddev.memcached.php" >> .gitignore
         fi
         echo "✅ Memcached configured for Acquia"
+        ;;
+    "upsun")
+        ddev config --web-environment-add="PLATFORM_APPLICATION_NAME=drupal"
+        ddev config --web-environment-add="PLATFORM_PROJECT=${HOSITNG_SITE}"
+        ddev config --web-environment-add="PLATFORM_ENVIRONMENT=${HOSTING_ENV}"
+        if ! ddev add-on list | grep -q "ddev-platformsh"; then
+            echo "Installing Platformsh add-on Upsun..."
+            ddev add-on get ddev/ddev-platformsh
+        fi
+        echo "✅ Platform configured for Upsun"
         ;;
 esac
 
@@ -334,6 +364,15 @@ case "$HOST_PROVIDER" in
             echo "⚠️  .htaccess file not found at $HTACCESS_PATH"
         fi
         ;;
+    "upsun")
+        # Configure nginx proxy for Upsun
+        if [ -n "$NGINX_FILE_PROXY" ]; then
+            if [ ! -f ".ddev/nginx_full/nginx-site.conf" ] && [ -f ".ddev/nginx_full/nginx-site.tmpl" ] ; then
+                envsubst '${NGINX_FILE_PROXY}' < .ddev/nginx_full/nginx-site.tmpl > .ddev/nginx_full/nginx-site.conf
+                echo "✅ Updated nginx proxy to redirect to: $NGINX_FILE_PROXY"
+            fi
+        fi
+        ;;
 esac
 
 # Start DDEV with new configuration
@@ -363,6 +402,12 @@ case "$HOST_PROVIDER" in
         echo "   ddev config global --web-environment-add=ACQUIA_API_KEY=your_api_key"
         echo "   ddev config global --web-environment-add=ACQUIA_API_SECRET=your_api_secret"
         echo "   💡 Get credentials: https://cloud.acquia.com/a/profile/tokens"
+        echo ""
+        ;;
+    "upsun")
+        echo "1. 🔑 Set your Upsun API Token globally (if not already set):"
+        echo "   ddev config global --web-environment-add=PLATFORMSH_CLI_TOKEN=your_api_key"
+        echo "   💡 Get credentials: https://console.upsun.com/-/users/me/settings"
         echo ""
         ;;
 esac

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -297,7 +297,7 @@ case "$HOST_PROVIDER" in
         ddev config --web-environment-add="PLATFORM_APPLICATION_NAME=drupal"
         ddev config --web-environment-add="PLATFORM_PROJECT=${HOSTING_SITE}"
         ddev config --web-environment-add="PLATFORM_ENVIRONMENT=${HOSTING_ENV}"
-        if ! ddev add-on list | grep -q "ddev-platformsh"; then
+        if ! ddev add-on list --installed | grep -q "ddev-platformsh"; then
             echo "Installing Platformsh add-on Upsun..."
             ddev add-on get ddev/ddev-platformsh
         fi
@@ -312,10 +312,8 @@ case "$HOST_PROVIDER" in
     "pantheon")
         # Configure nginx proxy for Pantheon
         if [ -n "$HOSTING_SITE" ] && [ -n "$HOSTING_ENV" ]; then
-            if [ -f ".ddev/nginx_full/nginx-site.conf" ]; then
-                sed -i.bak "s/HOSTING_ENV-HOSTING_SITE/$HOSTING_ENV-$HOSTING_SITE/g" .ddev/nginx_full/nginx-site.conf
-                sed -i.bak "s/HOSTING_DOMAIN/pantheonsite.io/g" .ddev/nginx_full/nginx-site.conf
-                rm -f .ddev/nginx_full/nginx-site.conf.bak
+            if [ ! -f ".ddev/nginx_full/nginx-site.conf" ] && [ -f ".ddev/nginx_full/nginx-site.tmpl" ] ; then
+                envsubst '${NGINX_FILE_PROXY}' < .ddev/nginx_full/nginx-site.tmpl > .ddev/nginx_full/nginx-site.conf
                 echo "✅ Updated nginx proxy to redirect to: $HOSTING_ENV-$HOSTING_SITE.pantheonsite.io"
             fi
         fi

--- a/commands/web/db-refresh
+++ b/commands/web/db-refresh
@@ -59,9 +59,13 @@ elif [[ "$HOSTING_PROVIDER" == "acquia" ]]; then
   echo -e "${green}Using Acquia refresh script...${NC}"
   # Call the Acquia-specific refresh script
   bash .ddev/scripts/refresh-acquia.sh "$ENVIRONMENT" "$FORCE_BACKUP"
+elif [[ "$HOSTING_PROVIDER" == "upsun" ]]; then
+  echo -e "${green}Using Upsun refresh script...${NC}"
+  # Call the Upsun-specific refresh script
+  bash .ddev/scripts/refresh-upsun.sh "$ENVIRONMENT" "$FORCE_BACKUP"
 else
   echo -e "${red}Hosting platform '$HOSTING_PROVIDER' not supported${NC}"
-  echo -e "${yellow}Supported platforms: pantheon, acquia${NC}"
+  echo -e "${yellow}Supported platforms: pantheon, acquia, upsun${NC}"
   exit 1
 fi
 

--- a/install.yaml
+++ b/install.yaml
@@ -194,6 +194,9 @@ removal_action:
   rm -f commands/web/theme-npx 2>/dev/null || true
   rm -f commands/web/theme-watch 2>/dev/null || true
 
+  # Remove from web-entrypoint.d
+  rm -f web-entrypoint.d/replace-nginx-file-proxy.sh 2>/dev/null || true
+
   echo "✅ Custom commands removed"
 
   # Remove PHP xdebug file, scripts, and nginx config (if exists)

--- a/install.yaml
+++ b/install.yaml
@@ -6,6 +6,7 @@ project_files:
 - scripts/
 - php/
 - nginx_full/
+- web-entrypoint.d/
 
 # DDEV version constraint
 ddev_version_constraint: ">= v1.22.0"

--- a/nginx_full/nginx-site.tmpl
+++ b/nginx_full/nginx-site.tmpl
@@ -1,9 +1,12 @@
 # ddev drupal kanopi config
 
+#ddev-generated
+
 # Custom configuration - ddev-generated line removed to prevent overwriting
 # If you want to take over this file and customize it, remove the line above
 # and ddev will respect it and won't overwrite the file.
 # See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+
 
 server {
     listen 80 default_server;
@@ -41,7 +44,7 @@ server {
 
     # This needs to be hardcode to the environment we're proxying from as part of NGINX
     location @proxy {
-      rewrite ^/(.*)$ https://HOSTING_ENV-HOSTING_SITE.HOSTING_DOMAIN/$1;
+      rewrite ^/(.*)$ ${NGINX_FILE_PROXY}/$1;
     }
 
     # pass the PHP scripts to FastCGI server listening on socket

--- a/scripts/refresh-upsun.sh
+++ b/scripts/refresh-upsun.sh
@@ -39,7 +39,7 @@ refresh_upsun_database() {
     echo -e "${green}${divider}${NC}"
     
     # Define the local database dump file path
-    DB_DUMP="/tmp/upsun_backup.${SITE_ENV}.sql.gz"
+    DB_DUMP="/tmp/upsun_backup.${ENVIRONMENT}.sql.gz"
 
     echo -e "\nChecking for local database dump file..."
 

--- a/scripts/refresh-upsun.sh
+++ b/scripts/refresh-upsun.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+## Upsun database refresh script
+## Called from the main refresh command when HOSTING_PROVIDER=upsun
+
+#ddev-generated
+
+green='\033[0;32m'
+yellow='\033[1;33m'
+red='\033[0;31m'
+NC='\033[0m'
+divider='===================================================\n'
+
+# Function to authenticate with Terminus
+authenticate_upsun() {
+    echo -e "\n${yellow} Authenticating with Upsun API Token... ${NC}"
+    # Get PLATFORMSH_CLI_TOKEN from environment
+    PLATFORMSH_CLI_TOKEN=$(printenv PLATFORMSH_CLI_TOKEN 2>/dev/null)
+    PLATFORMSH_USER_ID=$(platform auth:info id 2>/dev/null)
+    if [ -z "${PLATFORMSH_USER_ID:-}" ] && [ -z "${PLATFORMSH_CLI_TOKEN:-}" ]; then
+        echo -e "${red}PLATFORMSH_CLI_TOKEN environment variable is not set in the web container. Please configure it in your global ddev config.${NC}"
+        exit 1
+    fi
+
+    # Authenticate with platform using the machine token
+    if [ -z "${PLATFORMSH_USER_ID:-}" ] && ! platform auth:api-token-login; then
+        echo -e "${red}Failed to authenticate with Platform.sh CLI. Please check your PLATFORMSH_CLI_TOKEN.${NC}"
+        exit 1
+    fi
+    echo -e "${green}Successfully authenticated with Platform.sh CLI.${NC}"
+}
+
+# Function to refresh database from Upsun
+refresh_upsun_database() {
+    local ENVIRONMENT="$1"
+    local FORCE_BACKUP="$2"
+    
+    echo -e "\n${yellow} Get database from Upsun environment: ${ENVIRONMENT}. ${NC}"
+    echo -e "${green}${divider}${NC}"
+    
+    # Define the local database dump file path
+    DB_DUMP="/tmp/upsun_backup.${SITE_ENV}.sql.gz"
+
+    echo -e "\nChecking for local database dump file..."
+
+    # Calculate current time and 12-hour threshold.
+    CURRENT_TIME=$(date +%s)
+    TWELVE_HOURS_AGO=$((CURRENT_TIME - 43200))  # 12 hours = 43200 seconds
+
+    DOWNLOAD_NEW_BACKUP=false
+
+    # Check if force flag is set
+    if [ "$FORCE_BACKUP" = true ]; then
+        echo -e "${yellow}Force flag detected. Will download fresh backup regardless of local file age.${NC}"
+        DOWNLOAD_NEW_BACKUP=true
+    else
+        # Check if local dump file exists and its age
+        if [ -f "$DB_DUMP" ]; then
+            # Get file modification time using a more reliable method
+            LOCAL_FILE_TIME=""
+
+            # Try different methods to get the file modification time
+            if [ -z "$LOCAL_FILE_TIME" ]; then
+                # Method 1: Try stat with format specifier (GNU/Linux style)
+                LOCAL_FILE_TIME=$(stat -c %Y "$DB_DUMP" 2>/dev/null)
+            fi
+
+            if [ -z "$LOCAL_FILE_TIME" ]; then
+                # Method 2: Try stat with format specifier (BSD/macOS style)
+                LOCAL_FILE_TIME=$(stat -f %m "$DB_DUMP" 2>/dev/null)
+            fi
+
+            if [ -z "$LOCAL_FILE_TIME" ]; then
+                # Method 3: Use date command with file reference
+                LOCAL_FILE_TIME=$(date -r "$DB_DUMP" +%s 2>/dev/null)
+            fi
+
+            # Ensure we got a valid timestamp (numeric value)
+            if [ -n "$LOCAL_FILE_TIME" ] && echo "$LOCAL_FILE_TIME" | grep -q '^[0-9][0-9]*$'; then
+                if [ "$LOCAL_FILE_TIME" -lt "$TWELVE_HOURS_AGO" ]; then
+                    LOCAL_AGE_HOURS=$(( (CURRENT_TIME - LOCAL_FILE_TIME) / 3600 ))
+                    echo -e "${yellow}Local dump file is ${LOCAL_AGE_HOURS} hours old (older than 12 hours).${NC}"
+                    DOWNLOAD_NEW_BACKUP=true
+                else
+                    LOCAL_AGE_HOURS=$(( (CURRENT_TIME - LOCAL_FILE_TIME) / 3600 ))
+                    echo -e "${green}Recent local dump file found (${LOCAL_AGE_HOURS} hours old). Using existing file.${NC}"
+                fi
+            else
+                echo -e "${yellow}Could not determine local file age (got: '$LOCAL_FILE_TIME'). Will download fresh backup.${NC}"
+                DOWNLOAD_NEW_BACKUP=true
+            fi
+        else
+            echo -e "${yellow}No local dump file found.${NC}"
+            DOWNLOAD_NEW_BACKUP=true
+        fi
+    fi
+
+    # Download the database backup using terminus if needed
+    if [ "$DOWNLOAD_NEW_BACKUP" = true ]; then
+      echo -e "\nDownloading database backup from ${SITE_ENV}..."
+
+      # Remove old dump file if it exists before downloading
+      if [ -f "$DB_DUMP" ]; then
+          echo -e "${yellow}Removing old database dump file...${NC}"
+          rm -f "$DB_DUMP"
+      fi
+
+      platform db:dump -e ${ENVIRONMENT} --gzip -f ${DB_DUMP}
+    else
+      echo -e "\nUsing existing local database dump file."
+    fi
+
+    echo -e "\nReset DB"
+    drush sql-drop -y
+
+    echo -e "\nImport DB"
+    gunzip -c ${DB_DUMP} | $(drush sql:connect)
+}
+
+# Main execution
+authenticate_upsun
+refresh_upsun_database "$@"
+

--- a/web-entrypoint.d/replace-nginx-file-proxy.sh
+++ b/web-entrypoint.d/replace-nginx-file-proxy.sh
@@ -1,10 +1,10 @@
 # Check to see if the NGINX_FILE_PROXY env variable exists.
 if
   [ -n "${NGINX_FILE_PROXY}" ] && # Check to see if NGINX_FILE_PROXY variable exists.
-  [ -f ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.tmpl ] && # Check to see if template file exists.
-  grep -q "#ddev-generated" ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.conf; then # Check to make sure Nginx file hasn't been modified.
+  [ -f ${DDEV_APPROOT}/.ddev/nginx_full/nginx-site.tmpl ] && # Check to see if template file exists.
+  grep -q "#ddev-generated" ${DDEV_APPROOT}/.ddev/nginx_full/nginx-site.conf; then # Check to make sure Nginx file hasn't been modified.
   # Replace Env Variable in Nginx File.
-  envsubst '${NGINX_FILE_PROXY}' < ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.tmpl > ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.conf
+  envsubst '${NGINX_FILE_PROXY}' < ${DDEV_APPROOT}/.ddev/nginx_full/nginx-site.tmpl > ${DDEV_APPROOT}/.ddev/nginx_full/nginx-site.conf
   # Replace the existing nginx site file with the new one.
-  cp ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.conf /etc/nginx/sites-enabled/nginx-site.conf
+  cp ${DDEV_APPROOT}/.ddev/nginx_full/nginx-site.conf /etc/nginx/sites-enabled/nginx-site.conf
 fi

--- a/web-entrypoint.d/replace-nginx-file-proxy.sh
+++ b/web-entrypoint.d/replace-nginx-file-proxy.sh
@@ -1,0 +1,10 @@
+# Check to see if the NGINX_FILE_PROXY env variable exists.
+if
+  [ -n "${NGINX_FILE_PROXY}" ] && # Check to see if NGINX_FILE_PROXY variable exists.
+  [ -f ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.tmpl ] && # Check to see if template file exists.
+  grep -q "#ddev-generated" ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.conf; then # Check to make sure Nginx file hasn't been modified.
+  # Replace Env Variable in Nginx File.
+  envsubst '${NGINX_FILE_PROXY}' < ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.tmpl > ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.conf
+  # Replace the existing nginx site file with the new one.
+  cp ${PLATFORM_APP_DIR}/.ddev/nginx_full/nginx-site.conf /etc/nginx/sites-enabled/nginx-site.conf
+fi


### PR DESCRIPTION
## Description
- [x] Was AI used in this pull request?

> As a developer, I need Upsun hosting provider support in the DDEV Kanopi Drupal add-on.

This PR adds Upsun as a new hosting provider option alongside Pantheon and Acquia. Upsun is Platform.sh's next-generation PaaS, and this integration allows developers to pull databases and configure file proxies from Upsun environments.

**Current behavior:** The add-on supports Pantheon and Acquia hosting providers only.

**Updated behavior:** The add-on now supports Upsun as a third hosting provider with:
- Interactive configuration via `ddev project-configure`
- Database refresh from Upsun environments via `ddev db-refresh`
- NGINX file proxy for missing local files
- Automatic ddev-platformsh add-on installation

## Acceptance Criteria
* Selecting "upsun" in `ddev project-configure` prompts for Upsun-specific settings (application name, environment, nginx file proxy URL)
* `ddev db-refresh` successfully pulls database from Upsun environments using the Platform.sh CLI
* NGINX file proxy dynamically redirects missing files to the configured Upsun environment
* The nginx configuration uses a template approach with environment variable substitution
* Platform.sh CLI authentication works with `PLATFORMSH_CLI_TOKEN` environment variable

## Assumptions
* Users must have a valid `PLATFORMSH_CLI_TOKEN` configured globally via `ddev config global --web-environment-add=PLATFORMSH_CLI_TOKEN=your_token`
* The ddev-platformsh add-on is automatically installed when selecting Upsun as the hosting provider
* The nginx-site.conf is now generated from nginx-site.tmpl template file
* The web-entrypoint.d script regenerates the nginx config on container start if the template exists

## Steps to Validate
1. Install the add-on from this PR:
   ```bash
   ddev add-on get kanopi/ddev-kanopi-drupal --pr 27
   ```
2. Run `ddev project-configure` and select "upsun" as the hosting provider
3. Enter your Upsun application name, environment, and file proxy URL
4. Verify the configuration is saved correctly by running `ddev project-configure` again
5. Set your Platform.sh CLI token globally:
   ```bash
   ddev config global --web-environment-add=PLATFORMSH_CLI_TOKEN=your_token
   ```
6. Run `ddev db-refresh` and verify it pulls the database from Upsun
7. Verify file proxy works by accessing a file that exists on the remote but not locally

## Deploy Notes
**New Dependencies:**
- The `ddev-platformsh` add-on is automatically installed when Upsun is selected as the hosting provider

**New Files:**
- `scripts/refresh-upsun.sh` - Upsun-specific database refresh script
- `web-entrypoint.d/replace-nginx-file-proxy.sh` - Dynamic nginx proxy configuration script

**Configuration Requirements:**
- Users need to set `PLATFORMSH_CLI_TOKEN` globally before using `ddev db-refresh`
- Get your token at: https://console.upsun.com/-/users/me/settings

**Breaking Changes:**
- `nginx_full/nginx-site.conf` has been renamed to `nginx_full/nginx-site.tmpl` and is now a template file
- Existing Pantheon users may need to regenerate their nginx config by removing `nginx-site.conf` and running `ddev project-configure`
