### PR TITLE
Custom SSH DB Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,31 @@ ddev add-on remove kanopi-drupal
 
 ---
 
+## 🔑 SSH Key Configuration
+
+The refresh scripts use the `HOSTING_KEY` variable to select a specific SSH key from the agent. Set it in `.ddev/config.local.yaml`:
+
+```yaml
+web_environment:
+  - HOSTING_KEY=id_ed25519
+```
+
+The value should match the **comment** on your SSH key (the scripts use `ssh-add -L | grep "$HOSTING_KEY"` to find it). By default it looks for `id_rsa`.
+
+If your key doesn't have a comment or uses a different one, you can set or update it:
+
+```bash
+ssh-keygen -c -C "id_ed25519" -f ~/.ssh/id_ed25519
+```
+
+Verify the comment is set correctly:
+
+```bash
+ssh-add -L | grep id_ed25519
+```
+
+---
+
 ## 🤝 Contributing
 
 This add-on is maintained by [Kanopi Studios](https://kanopi.com). For issues, feature requests, or contributions, please visit our [GitHub repository](https://github.com/kanopi/ddev-kanopi-drupal).

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -121,6 +121,16 @@ case "${CURRENT_PROVIDER:-not set}" in
         echo "Upsun Environment: ${CURRENT_ENV:-not set}"
         echo "Nginx File Proxy: ${CURRENT_NGINX_FILE_PROXY:-not set}"
         ;;
+    "custom")
+        CURRENT_HOST=$(ddev exec printenv HOSTING_HOST 2>/dev/null || echo "")
+        CURRENT_USER=$(ddev exec printenv HOSTING_USER 2>/dev/null || echo "")
+        CURRENT_PORT=$(ddev exec printenv HOSTING_PORT 2>/dev/null || echo "")
+        CURRENT_PATH=$(ddev exec printenv HOSTING_PATH 2>/dev/null || echo "")
+        echo "Hosting Host: ${CURRENT_HOST:-not set}"
+        echo "Hosting User: ${CURRENT_USER:-not set}"
+        echo "Hosting Port: ${CURRENT_PORT:-not set}"
+        echo "Hosting Path: ${CURRENT_PATH:-not set}"
+        ;;
     *)
         echo "(Provider-specific settings will appear after selecting a provider)"
         ;;
@@ -133,7 +143,7 @@ echo ""
 # Get hosting provider
 echo "🏛️ Hosting Provider Configuration:"
 echo "----------------------------------"
-HOST_PROVIDER=$(select_option "Select your hosting provider:" "pantheon" "acquia", "upsun")
+HOST_PROVIDER=$(select_option "Select your hosting provider:" "pantheon" "acquia", "upsun", "custom")
 echo "✓ Selected: $HOST_PROVIDER"
 
 # Get hosting-specific configuration
@@ -164,8 +174,17 @@ case "$HOST_PROVIDER" in
         echo "🔗 File Proxy Configuration:"
         prompt_input "Proxy URL for missing files (e.g., https://your-site.com)" "${CURRENT_NGINX_FILE_PROXY}" NGINX_FILE_PROXY
         ;;
-
-
+    "custom")
+        echo "🔷 Custom Hosting Configuration:"
+        echo "-----------------------"
+        prompt_input "Hosting Host (Host/IP)" "${CURRENT_HOST}" HOSTING_HOST
+        prompt_input "Hosting User (User to loging with)" "${CURRENT_USER}" HOSTING_USER
+        prompt_input "Hosting Port (Default: 22)" "${CURRENT_PORT}" HOSTING_PORT
+        prompt_input "Hosting Path (Default: .)" "${CURRENT_PATH}" HOSTING_PATH
+        echo ""
+        echo "🔗 File Proxy Configuration:"
+        prompt_input "Proxy URL for missing files (e.g., https://your-site.com)" "${CURRENT_NGINX_FILE_PROXY}" NGINX_FILE_PROXY
+        ;;
 esac
 
 # Get theme configuration
@@ -238,8 +257,15 @@ ddev stop
 # Write hosting provider configuration
 echo "Setting hosting provider environment variables..."
 write_config_var "HOSTING_PROVIDER" "$HOST_PROVIDER"
-write_config_var "HOSTING_SITE" "$HOSTING_SITE"
-write_config_var "HOSTING_ENV" "$HOSTING_ENV"
+if [[ "$HOST_PROVIDER" != "custom" ]]; then
+    write_config_var "HOSTING_SITE" "$HOSTING_SITE"
+    write_config_var "HOSTING_ENV" "$HOSTING_ENV"
+else
+    write_config_var "HOSTING_HOST" "$HOSTING_HOST"
+    write_config_var "HOSTING_USER" "$HOSTING_USER"
+    write_config_var "HOSTING_PORT" "$HOSTING_PORT"
+    write_config_var "HOSTING_PATH" "$HOSTING_PATH"
+fi
 
 # Write theme variables
 echo "Setting theme configuration..."
@@ -260,7 +286,7 @@ case "$HOST_PROVIDER" in
             write_config_var "APACHE_FILE_PROXY" "$APACHE_FILE_PROXY"
         fi
         ;;
-    "pantheon"|"upsun")
+    "pantheon"|"upsun"|"custom")
         if [ -n "$NGINX_FILE_PROXY" ]; then
             write_config_var "NGINX_FILE_PROXY" "$NGINX_FILE_PROXY"
         fi
@@ -369,7 +395,7 @@ case "$HOST_PROVIDER" in
             echo "⚠️  .htaccess file not found at $HTACCESS_PATH"
         fi
         ;;
-    "upsun")
+    "upsun"|"custom")
         # Configure nginx proxy for Upsun
         if [ -n "$NGINX_FILE_PROXY" ]; then
             if [ ! -f ".ddev/nginx_full/nginx-site.conf" ] && [ -f ".ddev/nginx_full/nginx-site.tmpl" ] ; then

--- a/commands/host/project-configure
+++ b/commands/host/project-configure
@@ -143,7 +143,7 @@ echo ""
 # Get hosting provider
 echo "🏛️ Hosting Provider Configuration:"
 echo "----------------------------------"
-HOST_PROVIDER=$(select_option "Select your hosting provider:" "pantheon" "acquia", "upsun", "custom")
+HOST_PROVIDER=$(select_option "Select your hosting provider:" "pantheon" "acquia" "upsun" "custom")
 echo "✓ Selected: $HOST_PROVIDER"
 
 # Get hosting-specific configuration

--- a/commands/web/db-refresh
+++ b/commands/web/db-refresh
@@ -63,6 +63,10 @@ elif [[ "$HOSTING_PROVIDER" == "upsun" ]]; then
   echo -e "${green}Using Upsun refresh script...${NC}"
   # Call the Upsun-specific refresh script
   bash .ddev/scripts/refresh-upsun.sh "$ENVIRONMENT" "$FORCE_BACKUP"
+elif [[ "$HOSTING_PROVIDER" == "upsun" ]]; then
+  echo -e "${green}Using Custom refresh script...${NC}"
+  # Call the Upsun-specific refresh script
+  bash .ddev/scripts/refresh-custom.sh
 else
   echo -e "${red}Hosting platform '$HOSTING_PROVIDER' not supported${NC}"
   echo -e "${yellow}Supported platforms: pantheon, acquia, upsun${NC}"

--- a/commands/web/db-refresh
+++ b/commands/web/db-refresh
@@ -63,13 +63,13 @@ elif [[ "$HOSTING_PROVIDER" == "upsun" ]]; then
   echo -e "${green}Using Upsun refresh script...${NC}"
   # Call the Upsun-specific refresh script
   bash .ddev/scripts/refresh-upsun.sh "$ENVIRONMENT" "$FORCE_BACKUP"
-elif [[ "$HOSTING_PROVIDER" == "upsun" ]]; then
+elif [[ "$HOSTING_PROVIDER" == "custom" ]]; then
   echo -e "${green}Using Custom refresh script...${NC}"
-  # Call the Upsun-specific refresh script
+  # Call the Custom-specific refresh script
   bash .ddev/scripts/refresh-custom.sh
 else
   echo -e "${red}Hosting platform '$HOSTING_PROVIDER' not supported${NC}"
-  echo -e "${yellow}Supported platforms: pantheon, acquia, upsun${NC}"
+  echo -e "${yellow}Supported platforms: pantheon, acquia, upsun, custom${NC}"
   exit 1
 fi
 

--- a/scripts/refresh-custom.sh
+++ b/scripts/refresh-custom.sh
@@ -18,7 +18,7 @@ refresh_custom_database() {
     echo -e "${green}${divider}${NC}"
 
     # Define the local database dump file path
-    DB_DUMP="/tmp/db.sql"
+    DB_DUMP="${HOSTING_DB_DUMP:-/tmp/db.sql}"
     DB_DUMP_GZ="${DB_DUMP}.gz"
 
     echo -e "\nChecking for local database dump file..."
@@ -89,7 +89,7 @@ refresh_custom_database() {
         fi
 
 
-        ssh -p "${HOSTING_PORT:-22}" $HOSTING_KEY "${HOSTING_USER}@${HOSTING_HOST}" "cd ${HOSTING_PATH:-.}; ${HOSTING_DRUSH:-vendor/bin/drush} sql:dump --result-file=${DB_DUMP} --extra-dump=\"--disable-ssl --no-tablespaces\" ${HOSTING_DB_OPTIONS:---gzip}"
+        ssh -p "${HOSTING_PORT:-22}" $HOSTING_KEY "${HOSTING_USER}@${HOSTING_HOST}" "cd ${HOSTING_PATH:-.}; ${HOSTING_DRUSH:-vendor/bin/drush} sql:dump --result-file=${DB_DUMP} --extra-dump=\"--disable-ssl --no-tablespaces\" ${HOSTING_DB_DUMP_OPTIONS:---gzip}"
         rsync -avz -e "ssh -p ${HOSTING_PORT:-22} ${HOSTING_KEY}" --remove-source-files "${HOSTING_USER}@${HOSTING_HOST}:${DB_DUMP_GZ}" "${DB_DUMP_GZ}"
     else
         echo -e "\nUsing existing local database dump file."

--- a/scripts/refresh-custom.sh
+++ b/scripts/refresh-custom.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+## Custom database refresh script
+## Called from the main refresh command when HOSTING_PROVIDER=custom
+
+#ddev-generated
+
+green='\033[0;32m'
+yellow='\033[1;33m'
+red='\033[0;31m'
+NC='\033[0m'
+divider='===================================================\n'
+
+
+# Function to refresh database from Upsun
+refresh_custom_database() {
+    echo -e "\n${yellow} Get database from Upsun environment: ${ENVIRONMENT}. ${NC}"
+    echo -e "${green}${divider}${NC}"
+
+    # Define the local database dump file path
+    DB_DUMP="/tmp/db.sql"
+
+    echo -e "\nChecking for local database dump file..."
+
+    # Calculate current time and 12-hour threshold.
+    CURRENT_TIME=$(date +%s)
+    TWELVE_HOURS_AGO=$((CURRENT_TIME - 43200))  # 12 hours = 43200 seconds
+
+    DOWNLOAD_NEW_BACKUP=false
+
+    # Check if local dump file exists and its age
+    if [ -f "$DB_DUMP" ]; then
+        # Get file modification time using a more reliable method
+        LOCAL_FILE_TIME=""
+
+        # Try different methods to get the file modification time
+        if [ -z "$LOCAL_FILE_TIME" ]; then
+            # Method 1: Try stat with format specifier (GNU/Linux style)
+            LOCAL_FILE_TIME=$(stat -c %Y "$DB_DUMP" 2>/dev/null)
+        fi
+
+        if [ -z "$LOCAL_FILE_TIME" ]; then
+            # Method 2: Try stat with format specifier (BSD/macOS style)
+            LOCAL_FILE_TIME=$(stat -f %m "$DB_DUMP" 2>/dev/null)
+        fi
+
+        if [ -z "$LOCAL_FILE_TIME" ]; then
+            # Method 3: Use date command with file reference
+            LOCAL_FILE_TIME=$(date -r "$DB_DUMP" +%s 2>/dev/null)
+        fi
+
+        # Ensure we got a valid timestamp (numeric value)
+        if [ -n "$LOCAL_FILE_TIME" ] && echo "$LOCAL_FILE_TIME" | grep -q '^[0-9][0-9]*$'; then
+            if [ "$LOCAL_FILE_TIME" -lt "$TWELVE_HOURS_AGO" ]; then
+                LOCAL_AGE_HOURS=$(( (CURRENT_TIME - LOCAL_FILE_TIME) / 3600 ))
+                echo -e "${yellow}Local dump file is ${LOCAL_AGE_HOURS} hours old (older than 12 hours).${NC}"
+                DOWNLOAD_NEW_BACKUP=true
+            else
+                LOCAL_AGE_HOURS=$(( (CURRENT_TIME - LOCAL_FILE_TIME) / 3600 ))
+                echo -e "${green}Recent local dump file found (${LOCAL_AGE_HOURS} hours old). Using existing file.${NC}"
+            fi
+        else
+            echo -e "${yellow}Could not determine local file age (got: '$LOCAL_FILE_TIME'). Will download fresh backup.${NC}"
+            DOWNLOAD_NEW_BACKUP=true
+        fi
+    else
+        echo -e "${yellow}No local dump file found.${NC}"
+        DOWNLOAD_NEW_BACKUP=true
+    fi
+
+    # Download the database backup using terminus if needed
+    if [ "$DOWNLOAD_NEW_BACKUP" = true ]; then
+        echo -e "\nDownloading database backup from ${SITE_ENV}..."
+
+        # Remove old dump file if it exists before downloading
+        if [ -f "$DB_DUMP" ]; then
+            echo -e "${yellow}Removing old database dump file...${NC}"
+            rm -f "$DB_DUMP"
+        fi
+
+        if ( -z "$HOSTING_USER" ) || [ -z "$HOSTING_HOST" ]; then
+            echo "HOSTING_USER and HOSTING_HOST variables required."
+            exit 1
+        fi
+
+        if [[ "$HOSTING_KEY" != "" ]]; then
+            HOSTING_KEY="-i ${HOSTING_KEY}"
+        fi
+
+
+        ssh -p "${HOSTING_PORT:-22}" $HOSTING_KEY "${HOSTING_USER}@${HOSTING_HOST}" "cd ${HOSTING_PATH:-'.'}; ${HOSTING_DRUSH:-vendor/bin/drush} sql:dump --result-file=${DB_DUMP} --extra-dump=\"--disable-ssl --no-tablespaces\" ${HOSTING_DB_OPTIONS:-'--gzip'}"
+        rsync -avz -e "ssh -p ${HOSTING_PORT:-22} ${HOSTING_KEY}" --remove-source-files "${HOSTING_USER}@${HOSTING_HOST}:${DB_DUMP}.gz" "${DB_DUMP}.gz"
+    else
+        echo -e "\nUsing existing local database dump file."
+    fi
+
+    echo -e "\nReset DB"
+    drush sql-drop -y
+
+    echo -e "\nImport DB"
+    gunzip -c ${DB_DUMP} | $(drush sql:connect)
+}
+
+# Main execution
+refresh_custom_database
+

--- a/scripts/refresh-custom.sh
+++ b/scripts/refresh-custom.sh
@@ -12,13 +12,14 @@ NC='\033[0m'
 divider='===================================================\n'
 
 
-# Function to refresh database from Upsun
+# Function to refresh database from a custom SSH host
 refresh_custom_database() {
-    echo -e "\n${yellow} Get database from Upsun environment: ${ENVIRONMENT}. ${NC}"
+    echo -e "\n${yellow} Get database from custom host: ${HOSTING_USER}@${HOSTING_HOST}. ${NC}"
     echo -e "${green}${divider}${NC}"
 
     # Define the local database dump file path
     DB_DUMP="/tmp/db.sql"
+    DB_DUMP_GZ="${DB_DUMP}.gz"
 
     echo -e "\nChecking for local database dump file..."
 
@@ -29,24 +30,24 @@ refresh_custom_database() {
     DOWNLOAD_NEW_BACKUP=false
 
     # Check if local dump file exists and its age
-    if [ -f "$DB_DUMP" ]; then
+    if [ -f "$DB_DUMP_GZ" ]; then
         # Get file modification time using a more reliable method
         LOCAL_FILE_TIME=""
 
         # Try different methods to get the file modification time
         if [ -z "$LOCAL_FILE_TIME" ]; then
             # Method 1: Try stat with format specifier (GNU/Linux style)
-            LOCAL_FILE_TIME=$(stat -c %Y "$DB_DUMP" 2>/dev/null)
+            LOCAL_FILE_TIME=$(stat -c %Y "$DB_DUMP_GZ" 2>/dev/null)
         fi
 
         if [ -z "$LOCAL_FILE_TIME" ]; then
             # Method 2: Try stat with format specifier (BSD/macOS style)
-            LOCAL_FILE_TIME=$(stat -f %m "$DB_DUMP" 2>/dev/null)
+            LOCAL_FILE_TIME=$(stat -f %m "$DB_DUMP_GZ" 2>/dev/null)
         fi
 
         if [ -z "$LOCAL_FILE_TIME" ]; then
             # Method 3: Use date command with file reference
-            LOCAL_FILE_TIME=$(date -r "$DB_DUMP" +%s 2>/dev/null)
+            LOCAL_FILE_TIME=$(date -r "$DB_DUMP_GZ" +%s 2>/dev/null)
         fi
 
         # Ensure we got a valid timestamp (numeric value)
@@ -73,12 +74,12 @@ refresh_custom_database() {
         echo -e "\nDownloading database backup from ${SITE_ENV}..."
 
         # Remove old dump file if it exists before downloading
-        if [ -f "$DB_DUMP" ]; then
+        if [ -f "$DB_DUMP_GZ" ]; then
             echo -e "${yellow}Removing old database dump file...${NC}"
-            rm -f "$DB_DUMP"
+            rm -f "$DB_DUMP_GZ"
         fi
 
-        if ( -z "$HOSTING_USER" ) || [ -z "$HOSTING_HOST" ]; then
+        if [ -z "$HOSTING_USER" ] || [ -z "$HOSTING_HOST" ]; then
             echo "HOSTING_USER and HOSTING_HOST variables required."
             exit 1
         fi
@@ -88,8 +89,8 @@ refresh_custom_database() {
         fi
 
 
-        ssh -p "${HOSTING_PORT:-22}" $HOSTING_KEY "${HOSTING_USER}@${HOSTING_HOST}" "cd ${HOSTING_PATH:-'.'}; ${HOSTING_DRUSH:-vendor/bin/drush} sql:dump --result-file=${DB_DUMP} --extra-dump=\"--disable-ssl --no-tablespaces\" ${HOSTING_DB_OPTIONS:-'--gzip'}"
-        rsync -avz -e "ssh -p ${HOSTING_PORT:-22} ${HOSTING_KEY}" --remove-source-files "${HOSTING_USER}@${HOSTING_HOST}:${DB_DUMP}.gz" "${DB_DUMP}.gz"
+        ssh -p "${HOSTING_PORT:-22}" $HOSTING_KEY "${HOSTING_USER}@${HOSTING_HOST}" "cd ${HOSTING_PATH:-.}; ${HOSTING_DRUSH:-vendor/bin/drush} sql:dump --result-file=${DB_DUMP} --extra-dump=\"--disable-ssl --no-tablespaces\" ${HOSTING_DB_OPTIONS:---gzip}"
+        rsync -avz -e "ssh -p ${HOSTING_PORT:-22} ${HOSTING_KEY}" --remove-source-files "${HOSTING_USER}@${HOSTING_HOST}:${DB_DUMP_GZ}" "${DB_DUMP_GZ}"
     else
         echo -e "\nUsing existing local database dump file."
     fi
@@ -98,7 +99,7 @@ refresh_custom_database() {
     drush sql-drop -y
 
     echo -e "\nImport DB"
-    gunzip -c ${DB_DUMP} | $(drush sql:connect)
+    gunzip -c ${DB_DUMP_GZ} | $(drush sql:connect)
 }
 
 # Main execution

--- a/scripts/refresh-custom.sh
+++ b/scripts/refresh-custom.sh
@@ -84,13 +84,24 @@ refresh_custom_database() {
             exit 1
         fi
 
-        if [[ "$HOSTING_KEY" != "" ]]; then
-            HOSTING_KEY="-i ${HOSTING_KEY}"
+        # Load SSH key from agent
+        SSH_CMD="ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no -p ${HOSTING_PORT:-22}"
+        TEMP_KEY="/tmp/temp_key"
+        ssh-add -L | grep "${HOSTING_KEY:-id_rsa}" > "$TEMP_KEY"
+        if eval "$SSH_CMD -i ${TEMP_KEY} ${HOSTING_USER}@${HOSTING_HOST} 'echo SSH connection successful'"; then
+            echo -e "${green}SSH connection successful.${NC}"
+        else
+            echo -e "${red}Error: Cannot connect to remote host via SSH${NC}"
+            echo -e "${red}Please ensure:${NC}"
+            echo -e "${red}1. Your SSH key is properly configured on the remote server${NC}"
+            echo -e "${red}2. SSH agent is running: ddev auth ssh${NC}"
+            echo -e "${red}3. Your key is added to the remote server's ~/.ssh/authorized_keys${NC}"
+            echo -e "${red}4. Key name is set in config.local.yaml: HOSTING_KEY=your_key_name${NC}"
+            exit 1
         fi
 
-
-        ssh -p "${HOSTING_PORT:-22}" $HOSTING_KEY "${HOSTING_USER}@${HOSTING_HOST}" "cd ${HOSTING_PATH:-.}; ${HOSTING_DRUSH:-vendor/bin/drush} sql:dump --result-file=${DB_DUMP} --extra-dump=\"--disable-ssl --no-tablespaces\" ${HOSTING_DB_DUMP_OPTIONS:---gzip}"
-        rsync -avz -e "ssh -p ${HOSTING_PORT:-22} ${HOSTING_KEY}" --remove-source-files "${HOSTING_USER}@${HOSTING_HOST}:${DB_DUMP_GZ}" "${DB_DUMP_GZ}"
+        $SSH_CMD -i "${TEMP_KEY}" "${HOSTING_USER}@${HOSTING_HOST}" "cd ${HOSTING_PATH:-.}; ${HOSTING_DRUSH:-vendor/bin/drush} sql:dump --result-file=${DB_DUMP} --extra-dump=\"--disable-ssl --no-tablespaces\" ${HOSTING_DB_DUMP_OPTIONS:---gzip}"
+        rsync -avz -e "${SSH_CMD} -i ${TEMP_KEY}" --remove-source-files "${HOSTING_USER}@${HOSTING_HOST}:${DB_DUMP_GZ}" "${DB_DUMP_GZ}"
     else
         echo -e "\nUsing existing local database dump file."
     fi


### PR DESCRIPTION
## Description
- [ ] Was AI used in this pull request?

> As a developer, I need to be able to pull a database from a host that isn't Pantheon, Acquia, or Upsun (e.g. a generic VPS, a client-managed server, or any SSH-reachable Drupal install) so I can use `ddev db-refresh` consistently across every project regardless of where it's hosted.

Today, `ddev project-configure` only offers `pantheon`, `acquia`, and `upsun` as hosting providers, and `ddev db-refresh` only knows how to talk to those three platforms' APIs. Anything outside that set has to be refreshed by hand. This PR adds a fourth provider — `custom` — that pulls a database over plain SSH using a remote `drush sql:dump`, then `rsync`s the gzipped dump back to the container and imports it. It reuses the existing 12-hour local-cache logic so repeat refreshes are cheap.

## Acceptance Criteria
* `ddev project-configure` lists `custom` as a selectable hosting provider alongside `pantheon`, `acquia`, and `upsun`.
* When `custom` is selected, the wizard prompts for `HOSTING_HOST`, `HOSTING_USER`, `HOSTING_PORT` (default `22`), and `HOSTING_PATH` (default `.`), plus an optional `NGINX_FILE_PROXY` URL.
* Re-running `ddev project-configure` on a `custom`-configured project shows the previously-set custom values as defaults.
* `ddev db-refresh` on a `custom` project SSHes to the configured host, runs `drush sql:dump --gzip` remotely, rsyncs the resulting `.gz` dump back, drops the local DB, and imports.
* Reusing a local dump less than 12 hours old skips the SSH/rsync step (parity with the Pantheon/Acquia/Upsun behavior).
* `custom` projects get the nginx file-proxy template wired up the same way `upsun` projects do.
* The "unsupported provider" error path lists `custom` in its supported-platforms message.

## Assumptions
* The remote host has `drush` available at `vendor/bin/drush` (overridable via the `HOSTING_DRUSH` env var) and produces a gzipped dump when invoked with `--gzip`. If a project's drush layout differs, set `HOSTING_DRUSH` and/or `HOSTING_DB_DUMP_OPTIONS` in `web_environment` accordingly.
* The DDEV web container has an SSH key the remote host accepts. Consumers must run `ddev auth ssh` before `ddev db-refresh`. An optional `HOSTING_KEY` env var can point at a specific identity file.
* The dump path defaults to `/tmp/db.sql` (with the gzipped form at `/tmp/db.sql.gz`) inside the container, matching the convention used by the other providers' refresh scripts. It is overridable via `HOSTING_DB_DUMP` for projects that need a different on-disk path. The bare path is the canonical variable; the `.gz` form is derived so drush's `--gzip` flag stays the single source of truth for the suffix.
* Bats coverage for the `custom` provider path was deliberately deferred to a follow-up — meaningfully exercising it requires either a fixture SSH endpoint or stubbed `ssh`/`rsync`/`drush` binaries, which is a larger change than this PR. The change is small enough to validate manually against a real host.
* No companion change is being made in `ddev-kanopi-wp` in this PR. Per the cross-repo guidance in `CLAUDE.md`, the WP add-on should get a parallel `custom` provider in a follow-up to maintain feature parity.

## Steps to Validate
1. From a clean DDEV Drupal project, install this branch of the add-on: `ddev add-on get /path/to/this/checkout`.
2. Run `ddev project-configure` and confirm `custom` appears in the provider list (and that `pantheon`, `acquia`, `upsun` are still selectable and behave as before).
3. Select `custom` and provide a real SSH-reachable host running Drupal (host, user, port, path to docroot).
4. Run `ddev auth ssh` so the container has your key.
5. Run `ddev db-refresh` and confirm:
   * It prints `Using Custom refresh script...` followed by `Get database from custom host: <user>@<host>`.
   * It SSHes to the remote, produces `db.sql.gz` on the remote, rsyncs it back to the configured path in the web container (default `/tmp/db.sql.gz`), and imports successfully.
   * `drush status` against the local site shows the remote site's data.
6. Run `ddev db-refresh` again immediately and confirm it short-circuits with the "Recent local dump file found" message (i.e. the cache check now correctly looks at the `.gz` file).
7. Wait >12h (or `touch -d '13 hours ago' /tmp/db.sql.gz` inside the container) and re-run; confirm it re-downloads.
8. Override the default path: set `HOSTING_DB_DUMP=/tmp/alt.sql` in `web_environment`, restart, re-run `ddev db-refresh`, and confirm it produces and consumes `/tmp/alt.sql.gz`.
9. Run `ddev project-configure` a second time and confirm the previously-entered host/user/port/path values are shown as defaults.
10. Set `HOSTING_PROVIDER=bogus` and run `ddev db-refresh`; confirm the error lists `pantheon, acquia, upsun, custom`.
11. Repeat steps 1–7 against an existing Pantheon project to confirm no regression in the existing pantheon path.

## Affected URL
N/A — add-on changes; validate against any Drupal project that consumes this add-on.

## Deploy Notes
* No new runtime dependencies on the host — uses `ssh`, `rsync`, `gunzip`, all already present in the DDEV web container.
* Projects already configured with `pantheon`/`acquia`/`upsun` are unaffected; the new code paths only run when `HOSTING_PROVIDER=custom`.
* Consumers adopting `custom` need to: (a) re-run `ddev project-configure` to set the new `HOSTING_*` vars, (b) ensure `ddev auth ssh` has been run, and (c) optionally set any of `HOSTING_KEY`, `HOSTING_DRUSH`, `HOSTING_DB_DUMP`, or `HOSTING_DB_DUMP_OPTIONS` in `web_environment` if their setup differs from the defaults:
  * `HOSTING_KEY` — path to an SSH identity file (passed as `-i`).
  * `HOSTING_DRUSH` — remote drush binary path. Default: `vendor/bin/drush`.
  * `HOSTING_DB_DUMP` — on-disk dump path (without `.gz`). Default: `/tmp/db.sql`.
  * `HOSTING_DB_DUMP_OPTIONS` — extra flags passed to `drush sql:dump`. Default: `--gzip`. If you change this, make sure the resulting file is still gzipped, since the rsync target and import step both expect `${HOSTING_DB_DUMP}.gz`.
* Follow-up work: add bats coverage for the `custom` provider, and mirror this provider into `ddev-kanopi-wp`.